### PR TITLE
fix: repair bvm-init shims path

### DIFF
--- a/bvm-init.sh
+++ b/bvm-init.sh
@@ -11,5 +11,5 @@ else
     export PATH="$bvm_binary_paths:$PATH"
   fi
 
-  export PATH="$BVM_INSTALL_DIR/bin:$BVM_DATA_DIR/shims:$PATH"
+  export PATH="$BVM_INSTALL_DIR/bin:$BVM_INSTALL_DIR/shims:$PATH"
 fi


### PR DESCRIPTION
Previously used `BVM_DATA_DIR` does not work any more, use `BVM_INSTALL_DIR` instead.

closes: #26